### PR TITLE
Fix target reset when validation fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -135,7 +135,9 @@ def main():
         choice = main_menu(target, recon_mode, selected_modules)
         
         if choice == "1":
-            target = set_target()
+            new_target = set_target()
+            if new_target is not None:
+                target = new_target
         elif choice == "2":
             selected_modules = select_modules()
         elif choice == "3":


### PR DESCRIPTION
## Summary
- keep previous target if set_target() fails validation

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684952703e108325bd782c8db6831252